### PR TITLE
i17: Avoid imbalance in PROTECT/UNPROTECT within functions

### DIFF
--- a/src/r_difeq.h
+++ b/src/r_difeq.h
@@ -23,5 +23,5 @@ void difeq_r_harness(size_t n, size_t step,
 SEXP difeq_ptr_create(difeq_data *obj);
 void difeq_ptr_finalizer(SEXP extPtr);
 difeq_data* difeq_ptr_get(SEXP r_ptr);
-void r_difeq_cleanup(difeq_data *obj, SEXP r_ptr, SEXP r_y, SEXP r_out,
+void r_difeq_cleanup(difeq_data *obj, SEXP r_ptr, SEXP r_y,
                      bool return_history, bool return_pointer);

--- a/src/r_dopri.h
+++ b/src/r_dopri.h
@@ -37,6 +37,6 @@ SEXP dopri_ptr_create(dopri_data *obj);
 void dopri_ptr_finalizer(SEXP extPtr);
 dopri_data* dopri_ptr_get(SEXP r_ptr);
 void r_dopri_error(dopri_data* obj);
-void r_dopri_cleanup(dopri_data *obj, SEXP r_ptr, SEXP r_y, SEXP r_out,
+void r_dopri_cleanup(dopri_data *obj, SEXP r_ptr, SEXP r_y,
                      bool return_history, bool return_statistics,
                      bool return_pointer);


### PR DESCRIPTION
Every PROTECT call needs a corresponding UNPROTECT call and the easiest way to ensure these are in sync is to make sure that every individual function leaves the stack balanced.  This removes a bit of logic that in some cases would probably leave the stack imbalanced.  This would have been flagged by the rchk static analyser on CRAN so it's good to fix now