### PR TITLE
I14_2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dde
 Title: Solve Delay Differential Equations
-Version: 0.9.0
+Version: 0.9.1
 Authors@R: person("Rich", "FitzJohn", role = c("aut", "cre"),
     email = "rich.fitzjohn@gmail.com")
 Description: Solves ordinary and delay differential equations, where

--- a/src/dopri.c
+++ b/src/dopri.c
@@ -414,7 +414,19 @@ void dopri_integrate(dopri_data *obj, const double *y,
       }
       obj->t += h;
 
-      while (last ||
+      // The next six lines contain a workaround for a problem in which
+	  // gcc 4.9.3 on Win32 incorrectly optimises this (for -O1, -O2, and -O3)
+	  // changing the behaviour and causing too few iterations to take place
+	  // under certain circumstances.
+
+	  // The use of the variable `last`, along with the way the while loop
+	  // logic is now written, together seem to persuade gcc against whatever
+	  // optimisation causes the problem; it is difficult to tell exactly how.
+
+	  // See https://github.com/mrc-ide/dde/issues/14 for the original issue
+	  // and https://github.com/mrc-ide/dde/pull/19 for the specific changes.
+
+	  while (last ||
              obj->sign * obj->times[obj->times_idx] <= obj->sign * obj->t) {
         if (obj->times_idx >= obj->n_times) {
           // Exists so that we eventually exit on the 'last' integration step.

--- a/src/dopri.c
+++ b/src/dopri.c
@@ -429,6 +429,7 @@ void dopri_integrate(dopri_data *obj, const double *y,
 
         y_out += obj->n;
         obj->times_idx++;
+		if (last) break;
       }
 
       // Advance the ring buffer; we'll write to the next place after

--- a/src/dopri.c
+++ b/src/dopri.c
@@ -414,8 +414,12 @@ void dopri_integrate(dopri_data *obj, const double *y,
       }
       obj->t += h;
 
-      while (obj->times_idx < obj->n_times &&
+      while (last ||
              obj->sign * obj->times[obj->times_idx] <= obj->sign * obj->t) {
+        if (obj->times_idx >= obj->n_times) {
+          // Exists so that we eventually exit on the 'last' integration step.
+          break;
+        }
         // Here, it might be nice to allow transposed output or not;
         // that would be an argument to interpolate_all.  That's a bit
         // of a faff.
@@ -429,7 +433,6 @@ void dopri_integrate(dopri_data *obj, const double *y,
 
         y_out += obj->n;
         obj->times_idx++;
-        if (last) break;
       }
 
       // Advance the ring buffer; we'll write to the next place after

--- a/src/dopri.c
+++ b/src/dopri.c
@@ -419,12 +419,12 @@ void dopri_integrate(dopri_data *obj, const double *y,
 	  // changing the behaviour and causing too few iterations to take place
 	  // under certain circumstances.
 
-	  // The use of the variable `last`, along with the way the while loop
-	  // logic is now written, together seem to persuade gcc against whatever
-	  // optimisation causes the problem; it is difficult to tell exactly how.
+      // The use of the variable `last`, along with the way the while loop
+      // logic is now written, together seem to persuade gcc against whatever
+      // optimisation causes the problem; it is difficult to tell exactly how.
 
-	  // See https://github.com/mrc-ide/dde/issues/14 for the original issue
-	  // and https://github.com/mrc-ide/dde/pull/19 for the specific changes.
+      // See https://github.com/mrc-ide/dde/issues/14 for the original issue
+      // and https://github.com/mrc-ide/dde/pull/19 for the specific changes.
 
 	  while (last ||
              obj->sign * obj->times[obj->times_idx] <= obj->sign * obj->t) {

--- a/src/dopri.c
+++ b/src/dopri.c
@@ -415,9 +415,9 @@ void dopri_integrate(dopri_data *obj, const double *y,
       obj->t += h;
 
       // The next six lines contain a workaround for a problem in which
-	  // gcc 4.9.3 on Win32 incorrectly optimises this (for -O1, -O2, and -O3)
-	  // changing the behaviour and causing too few iterations to take place
-	  // under certain circumstances.
+      // gcc 4.9.3 on Win32 incorrectly optimises this (for -O1, -O2, and -O3)
+      // changing the behaviour and causing too few iterations to take place
+      // under certain circumstances.
 
       // The use of the variable `last`, along with the way the while loop
       // logic is now written, together seem to persuade gcc against whatever

--- a/src/dopri.c
+++ b/src/dopri.c
@@ -425,8 +425,7 @@ void dopri_integrate(dopri_data *obj, const double *y,
 
       // See https://github.com/mrc-ide/dde/issues/14 for the original issue
       // and https://github.com/mrc-ide/dde/pull/19 for the specific changes.
-
-	  while (last ||
+      while (last ||
              obj->sign * obj->times[obj->times_idx] <= obj->sign * obj->t) {
         if (obj->times_idx >= obj->n_times) {
           // Exists so that we eventually exit on the 'last' integration step.

--- a/src/dopri.c
+++ b/src/dopri.c
@@ -429,7 +429,7 @@ void dopri_integrate(dopri_data *obj, const double *y,
 
         y_out += obj->n;
         obj->times_idx++;
-		if (last) break;
+        if (last) break;
       }
 
       // Advance the ring buffer; we'll write to the next place after

--- a/src/dopri_5.c
+++ b/src/dopri_5.c
@@ -50,7 +50,6 @@ void dopri5_step(dopri_data *obj, double h) {
     *k5 = obj->k[4],
     *k6 = obj->k[5];
   double *y = obj->y, *y1 = obj->y1, *ysti = obj->k[6];
-  const void *data = obj->data;
 
   for (size_t i = 0; i < n; ++i) { // 22
     y1[i] = y[i] + h * A21 * k1[i];

--- a/src/dopri_853.c
+++ b/src/dopri_853.c
@@ -171,7 +171,6 @@ void dopri853_step(dopri_data *obj, double h) {
     *k9 = obj->k[8],
     *k10 = obj->k[9];
   double *y = obj->y, *y1 = obj->y1;
-  const void* data = obj->data;
 
   // TODO: do we need to call target here with y, k1?  Looks like
   // that's probably taken care of for us, as a similar call exists in

--- a/tests/testthat/test-ode.R
+++ b/tests/testthat/test-ode.R
@@ -411,7 +411,6 @@ test_that("step tuning", {
 
 
 test_that("integrate function with no absolute error", {
-  skip_on_appveyor()
   deriv <- function(t, y, p) {
     1
   }


### PR DESCRIPTION
This is the cleaned-up fix for issue 14, in which 32-bit gcc 4.9.3 on Windows with optimisation causes the while loop to be incorrectly skipped. 

Changing the while loop to different but compatible logic is enough to convince gcc that it shouldn't optimise the loop away.