### PR TITLE
mrc-2095: Allow forcing continuation with small step

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dde
 Title: Solve Delay Differential Equations
-Version: 1.0.2
+Version: 1.0.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),
@@ -24,7 +24,7 @@ Suggests:
     microbenchmark,
     rmarkdown,
     testthat
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1
 Roxygen: list(old_usage = TRUE)
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ check_all:
 
 clean:
 	rm -f src/*.o src/*.so src/*.dll
+	rm -f src/*.gcda src/*.gcno src/*.gcov
 	rm -f tests/testthat/*.o tests/testthat/*.so tests/testthat/*.dll
 	rm -f inst/examples/*.o inst/examples/*.so inst/examples/*.dll
 	rm -rf src/dde.so.dSYM

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dde 1.0.3
+
+* Added new option `step_size_min_allow`, which allows the solver to continue with a solution when a step size is driven too small (mrc-2095)
+
 # dde 1.0.2
 
 * Improved implementation of the replication interface, maintaining most backward compatibility (the `as_matrix` argument is defunct, at least for now) (mrc-1447)

--- a/R/dopri.R
+++ b/R/dopri.R
@@ -51,8 +51,10 @@
 ##'   used will be the largest of the absolute value of this
 ##'   \code{step_size_min} or \code{.Machine$double.eps}.  If the
 ##'   integration attempts to make a step smaller than this, it will
-##'   throw an error, stopping the integration (note that this differs
-##'   from the treatment of \code{hmin} in \code{deSolve::lsoda}).
+##'   throw an error by default, stopping the integration (note that
+##'   this differs from the treatment of \code{hmin} in
+##'   \code{deSolve::lsoda}). See \code{allow_step_size_min} to change
+##'   this behaviour.
 ##'
 ##' @param step_size_max The largest step size.  By default there is
 ##'   no maximum step size (Inf) so the solver can take as large a
@@ -69,6 +71,11 @@
 ##'   the number of evaluations of \code{func} will be about 6 times
 ##'   the number of steps (or 11 times if using \code{method =
 ##'   "dopri853"}).
+##'
+##' @param step_size_min_allow Logical, indicating if when a step size
+##'   is driven down to \code{step_size_min} we should allow it to
+##'   proceed. This is the behaviour in of \code{hmin} in
+##'   \code{deSolve::lsoda}.
 ##'
 ##' @param tcrit An optional vector of critical times that the solver
 ##'   must stop at (rather than interpolating over).  This can include
@@ -288,6 +295,7 @@ dopri <- function(y, times, func, parms, ...,
                   rtol = 1e-6, atol = 1e-6,
                   step_size_min = 0, step_size_max = Inf,
                   step_size_initial = 0, step_max_n = 100000L,
+                  step_size_min_allow = FALSE,
                   tcrit = NULL, event_time = NULL, event_function = NULL,
                   method = "dopri5",
                   stiff_check = 0,
@@ -335,6 +343,7 @@ dopri <- function(y, times, func, parms, ...,
   assert_scalar(step_size_max)
   assert_scalar(step_size_initial)
   assert_size(step_max_n)
+  assert_scalar_logical(step_size_min_allow)
   assert_size(n_history)
 
   assert_scalar_logical(grow_history)
@@ -398,6 +407,7 @@ dopri <- function(y, times, func, parms, ...,
                ## Step control:
                step_size_min, step_size_max,
                step_size_initial, as.integer(step_max_n),
+               step_size_min_allow,
                ## Critical and events
                as.numeric(tcrit), is_event, event,
                ## Other:

--- a/man/difeq_replicate.Rd
+++ b/man/difeq_replicate.Rd
@@ -4,9 +4,9 @@
 \alias{difeq_replicate}
 \title{Solve difference equations repeatedly}
 \usage{
-difeq_replicate(n, y, steps, target, parms, ..., n_out = 0L, n_history = 0L,
-  grow_history = FALSE, return_history = n_history > 0, dllname = "",
-  parms_are_real = TRUE, ynames = NULL, outnames = NULL,
+difeq_replicate(n, y, steps, target, parms, ..., n_out = 0L,
+  n_history = 0L, grow_history = FALSE, return_history = n_history > 0,
+  dllname = "", parms_are_real = TRUE, ynames = NULL, outnames = NULL,
   return_by_column = TRUE, return_initial = TRUE, return_step = TRUE,
   return_output_with_y = TRUE, restartable = FALSE,
   return_minimal = FALSE, as_array = TRUE)

--- a/man/dopri.Rd
+++ b/man/dopri.Rd
@@ -8,11 +8,12 @@
 \alias{ylag}
 \title{Integrate ODE/DDE with dopri}
 \usage{
-dopri(y, times, func, parms, ..., n_out = 0L, output = NULL, rtol = 1e-06,
-  atol = 1e-06, step_size_min = 0, step_size_max = Inf,
-  step_size_initial = 0, step_max_n = 100000L, tcrit = NULL,
-  event_time = NULL, event_function = NULL, method = "dopri5",
-  stiff_check = 0, verbose = FALSE, callback = NULL, n_history = 0,
+dopri(y, times, func, parms, ..., n_out = 0L, output = NULL,
+  rtol = 1e-06, atol = 1e-06, step_size_min = 0, step_size_max = Inf,
+  step_size_initial = 0, step_max_n = 100000L,
+  step_size_min_allow = FALSE, tcrit = NULL, event_time = NULL,
+  event_function = NULL, method = "dopri5", stiff_check = 0,
+  verbose = FALSE, callback = NULL, n_history = 0,
   grow_history = FALSE, return_history = n_history > 0, dllname = "",
   parms_are_real = TRUE, ynames = names(y), outnames = NULL,
   return_by_column = TRUE, return_initial = TRUE, return_time = TRUE,
@@ -65,8 +66,10 @@ will be less than this.}
 used will be the largest of the absolute value of this
 \code{step_size_min} or \code{.Machine$double.eps}.  If the
 integration attempts to make a step smaller than this, it will
-throw an error, stopping the integration (note that this differs
-from the treatment of \code{hmin} in \code{deSolve::lsoda}).}
+throw an error by default, stopping the integration (note that
+this differs from the treatment of \code{hmin} in
+\code{deSolve::lsoda}). See \code{allow_step_size_min} to change
+this behaviour.}
 
 \item{step_size_max}{The largest step size.  By default there is
 no maximum step size (Inf) so the solver can take as large a
@@ -83,6 +86,11 @@ solver takes more steps than this it will throw an error.  Note
 the number of evaluations of \code{func} will be about 6 times
 the number of steps (or 11 times if using \code{method =
 "dopri853"}).}
+
+\item{step_size_min_allow}{Logical, indicating if when a step size
+is driven down to \code{step_size_min} we should allow it to
+proceed. This is the behaviour in of \code{hmin} in
+\code{deSolve::lsoda}.}
 
 \item{tcrit}{An optional vector of critical times that the solver
 must stop at (rather than interpolating over).  This can include

--- a/src/dopri.c
+++ b/src/dopri.c
@@ -111,7 +111,7 @@ dopri_data* dopri_data_copy(const dopri_data* obj) {
   ret->step_size_max = obj->step_size_max;
   ret->step_size_initial = obj->step_size_initial;
   ret->step_max_n = obj->step_max_n;
-  ret->step_size_min_allow = false;
+  ret->step_size_min_allow = obj->step_size_min_allow;
   ret->step_beta = obj->step_beta;
   ret->step_constant = obj->step_constant;
 

--- a/src/dopri.h
+++ b/src/dopri.h
@@ -140,6 +140,7 @@ typedef struct {
   double step_size_max;
   double step_size_initial;
   size_t step_max_n; // max number of steps (100000)
+  bool step_size_min_allow;
   double step_beta;
   double step_constant; // internal
 

--- a/src/r_dopri.c
+++ b/src/r_dopri.c
@@ -30,6 +30,7 @@ SEXP r_dopri(SEXP r_y_initial, SEXP r_times, SEXP r_func, SEXP r_data,
              // Step size control:
              SEXP r_step_size_min, SEXP r_step_size_max,
              SEXP r_step_size_initial, SEXP r_step_max_n,
+             SEXP r_step_size_min_allow,
              // Critical times and events:
              SEXP r_tcrit, SEXP r_is_event, SEXP r_events,
              // Other:
@@ -159,6 +160,7 @@ SEXP r_dopri(SEXP r_y_initial, SEXP r_times, SEXP r_func, SEXP r_data,
   obj->step_size_max = fmin(fabs(REAL(r_step_size_max)[0]), DBL_MAX);
   obj->step_size_initial = REAL(r_step_size_initial)[0];
   obj->step_max_n = INTEGER(r_step_max_n)[0];
+  obj->step_size_min_allow = INTEGER(r_step_size_min_allow)[0];
 
   obj->stiff_check = INTEGER(r_stiff_check)[0];
 

--- a/src/r_dopri.h
+++ b/src/r_dopri.h
@@ -8,6 +8,7 @@ SEXP r_dopri(SEXP r_y_initial, SEXP r_times, SEXP r_func, SEXP r_data,
              SEXP r_rtol, SEXP r_atol,
              SEXP r_step_size_min, SEXP r_step_size_max,
              SEXP r_step_size_initial, SEXP r_step_max_n,
+             SEXP r_step_size_min_allow,
              // Critical times and events:
              SEXP r_tcrit, SEXP r_is_event, SEXP r_events,
              // Other:

--- a/src/zzz.c
+++ b/src/zzz.c
@@ -8,7 +8,7 @@
 #include <Rversion.h>
 
 static const R_CallMethodDef call_methods[] = {
-  {"Cdopri",          (DL_FUNC) &r_dopri,             26},
+  {"Cdopri",          (DL_FUNC) &r_dopri,             27},
   {"Cdopri_continue", (DL_FUNC) &r_dopri_continue,    10},
   {"Cdopri_copy",     (DL_FUNC) &r_dopri_copy,         1},
   {"Cylag",           (DL_FUNC) &r_ylag,               2},

--- a/tests/testthat/test-ode.R
+++ b/tests/testthat/test-ode.R
@@ -410,6 +410,29 @@ test_that("step tuning", {
 })
 
 
+test_that("allow step size to get small", {
+  tt <- seq(0, 1, length.out = 200)
+  T_IDX <- 16L
+  m0 <- run_lorenz_dde(tt, n_history = 500, return_statistics = TRUE)
+  t0 <- attr(m0, "history")[T_IDX, ]
+  s0 <- attr(m0, "statistics")
+
+  step_size_min <- 0.01
+  m1 <- run_lorenz_dde(tt,
+                       step_size_min = step_size_min,
+                       step_size_min_allow = TRUE,
+                       n_history = 500,
+                       return_statistics = TRUE)
+  t1 <- attr(m1, "history")[T_IDX, ]
+  ## This is really annoying, as we might be off by a _very_ small
+  ## amount (~1e-18) due to general floating point horrors.
+  expect_lt(min(diff(t1) - step_size_min), 1e-16)
+  expect_equal(min(diff(t1)), step_size_min)
+  s1 <- attr(m1, "statistics")
+  expect_lt(s1[["n_eval"]], s0[["n_eval"]])
+})
+
+
 test_that("integrate function with no absolute error", {
   deriv <- function(t, y, p) {
     1


### PR DESCRIPTION
This PR adds *another* option to dopri, allowing integration to continue even after the step size has been driven down to `step_size_min`; this is the behaviour of lsoda and allows us to trade off accuracy for performance when we can't get the atol/rtol control parameters to do our bidding.

If this does the trick we'd want to make a similar set of changes to https://github.com/mrc-ide/dopri-js 