### PR TITLE
Fix non-portable printf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dde
 Title: Solve Delay Differential Equations
-Version: 1.0.4
+Version: 1.0.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/src/difeq.c
+++ b/src/difeq.c
@@ -266,7 +266,7 @@ const double* difeq_find_step(difeq_data *obj, int step) {
   }
   if (h == NULL) {
     Rf_error("difeq failure: did not find step in history (at step %d)",
-             obj->step);
+             (int)obj->step);
   }
   return ((double*) h) + obj->history_idx_y;
 }

--- a/src/dopri.c
+++ b/src/dopri.c
@@ -330,7 +330,7 @@ void dopri_integrate(dopri_data *obj, const double *y,
   for (size_t i = 0; i < obj->n; ++i) {
     if (!R_FINITE(obj->k[0][i])) {
       Rf_error("non-finite derivative at initial time for element %d\n",
-               i + 1);
+               (int)i + 1);
     }
   }
 

--- a/src/r_difeq.c
+++ b/src/r_difeq.c
@@ -212,7 +212,7 @@ void difeq_r_harness(size_t n, size_t step,
   // Ensure that we get sensible output from the target function:
   if ((size_t)length(ans) != n) {
     Rf_error("Incorrect length variable output: expected %d, recieved %d",
-             n, length(ans));
+             (int)n, (int)length(ans));
   }
   memcpy(ynext, REAL(ans), n * sizeof(double));
   if (n_out > 0) {
@@ -221,7 +221,7 @@ void difeq_r_harness(size_t n, size_t step,
       Rf_error("Missing output");
     } else if ((size_t)length(r_output) != n_out) {
       Rf_error("Incorrect length output: expected %d, recieved %d",
-               n_out, length(r_output));
+               (int)n_out, (int)length(r_output));
     } else if (TYPEOF(r_output) != REALSXP) {
       Rf_error("Incorrect type output");
     }

--- a/src/r_dopri.c
+++ b/src/r_dopri.c
@@ -90,7 +90,7 @@ SEXP r_dopri(SEXP r_y_initial, SEXP r_times, SEXP r_func, SEXP r_data,
         } else {
           events[i] = (event_func*)ptr_fn_get(el);
           if (events[i] == NULL) {
-            Rf_error("Was passed null pointer for events[%d]", j);
+            Rf_error("Was passed null pointer for events[%d]", (int)j);
           }
         }
       }

--- a/src/util.c
+++ b/src/util.c
@@ -33,7 +33,7 @@ double scalar_double(SEXP x) {
 
 int check_index_bounds(int x, size_t len) {
   if (x < 1 || x > (int)len) {
-    Rf_error("Expected index on [1..%d] (%d out of bounds)", len, x);
+    Rf_error("Expected index on [1..%d] (%d out of bounds)", (int)len, x);
   }
   return x - 1;
 }


### PR DESCRIPTION
This PR fixes non-portable print statements or `size_t` values, which we solve by casting to int - none of the offending cases will ever be out of range for this.